### PR TITLE
without this condition, it will raise an unwanted IndexError

### DIFF
--- a/dict_digger/__init__.py
+++ b/dict_digger/__init__.py
@@ -13,7 +13,8 @@ def dig(your_dict, *keys, **kwargs):
     for key in keys:
         if isinstance(end_of_chain, dict) and key in end_of_chain:
             end_of_chain = end_of_chain[key]
-        elif isinstance(end_of_chain, (list, tuple)) and isinstance(key, int):
+        elif isinstance(end_of_chain, (list, tuple)) and isinstance(key, int) \
+                and key < len(end_of_chain):
             end_of_chain = end_of_chain[key]
         else:
             if 'fail' in kwargs and kwargs['fail'] is True:


### PR DESCRIPTION
@jtushman  for instance:
`x = {'a': [1,2,3]}`
`dig(x, 'a', 10)`
will raise an unwanted IndexError even though `fail` parameter is not set to `True`
